### PR TITLE
Save workflow-job-folder to tmp instead of cwd

### DIFF
--- a/ocrd_webapi/routers/workflow.py
+++ b/ocrd_webapi/routers/workflow.py
@@ -73,9 +73,9 @@ async def list_workflows() -> List[WorkflowRsrc]:
     return response
 
 
-@router.get("/workflow/{workflow_id}")
+@router.get("/workflow/{workflow_id}", response_model=None)
 async def get_workflow_script(workflow_id: str, accept: str = Header(...)
-) -> Union[WorkflowRsrc, FileResponse, ResponseException]:
+) -> Union[WorkflowRsrc, FileResponse]:
     """
     Get the Nextflow script of an existing workflow space.
     Specify your download path with --output
@@ -114,9 +114,9 @@ async def get_workflow_script(workflow_id: str, accept: str = Header(...)
     )
 
 
-@router.get("/workflow/{workflow_id}/{job_id}", responses={"200": {"model": WorkflowJobRsrc}})
+@router.get("/workflow/{workflow_id}/{job_id}", responses={"200": {"model": WorkflowJobRsrc}}, response_model=None)
 async def get_workflow_job(workflow_id: str, job_id: str, accept: str = Header(...)
-) -> Union[WorkflowJobRsrc, FileResponse, ResponseException]:
+) -> Union[WorkflowJobRsrc, FileResponse]:
     """
     Query a job from the database. Used to query if a job is finished or still running
 
@@ -165,7 +165,7 @@ async def get_workflow_job(workflow_id: str, job_id: str, accept: str = Header(.
 
 @router.post("/workflow/{workflow_id}", responses={"201": {"model": WorkflowJobRsrc}})
 async def run_workflow(workflow_id: str, workflow_args: WorkflowArgs
-) -> Union[WorkflowJobRsrc, ResponseException]:
+) -> WorkflowJobRsrc:
     """
     Trigger a Nextflow execution by using a Nextflow script with id {workflow_id} on a
     workspace with id {workspace_id}. The OCR-D results are stored inside the {workspace_id}.
@@ -199,7 +199,7 @@ async def run_workflow(workflow_id: str, workflow_args: WorkflowArgs
 @router.post("/workflow", responses={"201": {"model": WorkflowRsrc}})
 async def upload_workflow_script(nextflow_script: UploadFile,
                                  auth: HTTPBasicCredentials = Depends(security)
-) -> Union[WorkflowRsrc, ResponseException]:
+) -> WorkflowRsrc:
     """
     Create a new workflow space. Upload a Nextflow script inside.
 
@@ -220,7 +220,7 @@ async def upload_workflow_script(nextflow_script: UploadFile,
 @router.put("/workflow/{workflow_id}", responses={"201": {"model": WorkflowRsrc}})
 async def update_workflow_script(nextflow_script: UploadFile, workflow_id: str,
                                  auth: HTTPBasicCredentials = Depends(security)
-) -> Union[WorkflowRsrc, ResponseException]:
+) -> WorkflowRsrc:
     """
     Update or create a new workflow space. Upload a Nextflow script inside.
 

--- a/ocrd_webapi/routers/workflow.py
+++ b/ocrd_webapi/routers/workflow.py
@@ -141,14 +141,6 @@ async def get_workflow_job(workflow_id: str, job_id: str, accept: str = Header(.
         # TODO: Don't provide the exception message to the outside world
         raise ResponseException(500, {"error": f"internal server error: {e}"})
 
-    if accept == "application/json":
-        return WorkflowJobRsrc.create(
-            job_url=wf_job_url,
-            workflow_url=workflow_url,
-            workspace_url=workspace_url,
-            job_state=job_state
-        )
-
     if accept == "application/vnd.zip":
         tempdir = tempfile.mkdtemp(prefix="ocrd-wf-job-zip-")
         job_archive_path = make_archive(
@@ -158,10 +150,11 @@ async def get_workflow_job(workflow_id: str, job_id: str, accept: str = Header(.
         )
         return FileResponse(job_archive_path)
 
-    raise HTTPException(
-        status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-        "Unsupported media, expected application/json \
-        or application/vnd.zip",
+    return WorkflowJobRsrc.create(
+        job_url=wf_job_url,
+        workflow_url=workflow_url,
+        workspace_url=workspace_url,
+        job_state=job_state
     )
 
 

--- a/ocrd_webapi/routers/workflow.py
+++ b/ocrd_webapi/routers/workflow.py
@@ -3,6 +3,7 @@ from os import getenv
 from secrets import compare_digest
 from shutil import make_archive
 from typing import List, Union
+import tempfile
 
 
 from fastapi import (
@@ -149,8 +150,9 @@ async def get_workflow_job(workflow_id: str, job_id: str, accept: str = Header(.
         )
 
     if accept == "application/vnd.zip":
+        tempdir = tempfile.mkdtemp(prefix="ocrd-wf-job-zip-")
         job_archive_path = make_archive(
-            base_name=job_id,
+            base_name=f'{tempdir}/{job_id}',
             format='zip',
             root_dir=wf_job_local,
         )

--- a/ocrd_webapi/routers/workspace.py
+++ b/ocrd_webapi/routers/workspace.py
@@ -49,12 +49,12 @@ async def list_workspaces() -> List[WorkspaceRsrc]:
     return response
 
 
-@router.get("/workspace/{workspace_id}")
+@router.get("/workspace/{workspace_id}", response_model=None)
 async def get_workspace(
         background_tasks: BackgroundTasks,
         workspace_id: str,
         accept: str = Header(...)
-) -> Union[WorkspaceRsrc, FileResponse, ResponseException]:
+) -> Union[WorkspaceRsrc, FileResponse]:
     """
     Get an existing workspace
 
@@ -87,7 +87,7 @@ async def get_workspace(
 
 
 @router.post("/workspace", responses={"201": {"model": WorkspaceRsrc}})
-async def post_workspace(workspace: UploadFile) -> Union[WorkspaceRsrc, ResponseException]:
+async def post_workspace(workspace: UploadFile) -> WorkspaceRsrc:
     """
     Create a new workspace
 
@@ -106,7 +106,7 @@ async def post_workspace(workspace: UploadFile) -> Union[WorkspaceRsrc, Response
 
 
 @router.put("/workspace/{workspace_id}", responses={"201": {"model": WorkspaceRsrc}})
-async def put_workspace(workspace: UploadFile, workspace_id: str) -> Union[WorkspaceRsrc, ResponseException]:
+async def put_workspace(workspace: UploadFile, workspace_id: str) -> WorkspaceRsrc:
     """
     Update or create a workspace
     """
@@ -123,7 +123,7 @@ async def put_workspace(workspace: UploadFile, workspace_id: str) -> Union[Works
 
 
 @router.delete("/workspace/{workspace_id}", responses={"200": {"model": WorkspaceRsrc}})
-async def delete_workspace(workspace_id: str) -> Union[WorkspaceRsrc, ResponseException]:
+async def delete_workspace(workspace_id: str) -> WorkspaceRsrc:
     """
     Delete a workspace
     curl -v -X DELETE 'http://localhost:8000/workspace/{workspace_id}'

--- a/tests/test_workflow_api.py
+++ b/tests/test_workflow_api.py
@@ -157,9 +157,11 @@ def test_job_status(client, auth, dummy_workflow_id, dummy_workspace_id):
     for x in range(0, 100):
         response = client.get(f"workflow/{dummy_workflow_id}/{job_id}")
         job_state = parse_job_state(response)
+        if job_state is None:
+            break
         if job_state == 'STOPPED' or job_state == 'SUCCESS':
             break
-        sleep(2)
+        sleep(3)
 
     assert (job_state == 'STOPPED' or job_state == 'SUCCESS'), \
         f"expecting job.state to be set to stopped/success but is {job_state}"


### PR DESCRIPTION
As discussed.
I am not sure if the implementation I made is good enough, as the zip in tmp gets not deleted after sending is complete. And I think the tmp gets only cleared after vm restart and not periodically or something.
This pr also contains a fix for an error which occurred to me. Feel free to take parts of this pr or ignore it completely.