### PR TITLE
Adaption to core PR processing server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,20 @@ RUN apt-get update && apt-get -y install \
     make \
     python3-dev \
     python3-pip \
-    && curl -s https://get.nextflow.io | bash \
-    && mv nextflow /usr/local/bin/ \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-    
-RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools 
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --shell /bin/bash nextflow
+
+RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools
 RUN python3 -m pip install --no-cache-dir --upgrade -r /code/requirements.txt
 RUN pip3 install .
 
-CMD ["uvicorn", "ocrd_webapi.main:app", "--host", "0.0.0.0", "--port", "8000"]
+USER nextflow
+RUN cd $HOME \
+    && curl -s https://get.nextflow.io | bash \
+    && mkdir -p $HOME/.local/bin \
+    && mv nextflow $HOME/.local/bin/
 
+ENV PATH "${PATH}:/home/nextflow/.local/bin"
+
+CMD ["uvicorn", "ocrd_webapi.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/ocrd_webapi/database.py
+++ b/ocrd_webapi/database.py
@@ -44,7 +44,7 @@ async def sync_initiate_database(db_url: str, db_name: str = None, doc_models: L
 
 
 async def get_workflow(workflow_id) -> Union[WorkflowDB, None]:
-    return await WorkflowDB.get(workflow_id)
+    return await WorkflowDB.find_one(WorkflowDB.workflow_id == workflow_id)
 
 
 @call_sync
@@ -53,7 +53,7 @@ async def sync_get_workflow(workflow_id) -> Union[WorkflowDB, None]:
 
 
 async def get_workflow_path(workflow_id) -> Union[str, None]:
-    workflow = await WorkflowDB.get(workflow_id)
+    workflow = await get_workflow(workflow_id)
     if workflow:
         return workflow.workflow_path
     logger.warning(f"Trying to get a workflow path of a non-existing workflow_id: {workflow_id}")
@@ -66,7 +66,7 @@ async def sync_get_workflow_path(workflow_id) -> Union[str, None]:
 
 
 async def get_workflow_script_path(workflow_id) -> Union[str, None]:
-    workflow = await WorkflowDB.get(workflow_id)
+    workflow = await get_workflow(workflow_id)
     if workflow:
         return workflow.workflow_script_path
     logger.warning(f"Trying to get a workflow script path of a non-existing workflow_id: {workflow_id}")
@@ -79,7 +79,7 @@ async def sync_get_workflow_script_path(workflow_id) -> Union[str, None]:
 
 
 async def get_workflow_job(job_id) -> Union[WorkflowJobDB, None]:
-    return await WorkflowJobDB.get(job_id)
+    return await WorkflowJobDB.find_one(WorkflowJobDB.workflow_job_id == job_id)
 
 
 @call_sync
@@ -110,7 +110,7 @@ async def sync_get_workspace_mets_path(workspace_id) -> Union[str, None]:
 
 
 async def mark_deleted_workflow(workflow_id) -> bool:
-    wf = await WorkflowDB.get(workflow_id)
+    wf = await get_workflow(workflow_id)
     if wf:
         wf.deleted = True
         await wf.save()
@@ -146,7 +146,17 @@ async def sync_mark_deleted_workspace(workspace_id) -> bool:
 
 
 async def save_workflow(workflow_id: str, workflow_path: str, workflow_script_path: str) -> Union[WorkflowDB, None]:
-    workflow_db = WorkflowDB(_id=workflow_id, workflow_path=workflow_path, workflow_script_path=workflow_script_path)
+    workflow_db = await get_workflow(workflow_id)
+    if not workflow_db:
+        workflow_db = WorkflowDB(
+            workflow_id=workflow_id,
+            workflow_path=workflow_path,
+            workflow_script_path=workflow_script_path
+        )
+    else:
+        workflow_db.workflow_id = workflow_id
+        workflow_db.workflow_path = workflow_path
+        workflow_db.workflow_script_path = workflow_script_path
     await workflow_db.save()
     return workflow_db
 
@@ -210,9 +220,9 @@ async def sync_save_workspace(workspace_id: str, workspace_path: str, bag_info: 
 
 
 async def save_workflow_job(job_id: str, workflow_id: str, workspace_id: str, job_path: str, job_state: str
-) -> Union[WorkflowJobDB, None]:
+                            ) -> Union[WorkflowJobDB, None]:
     """
-    save a workflow_job to the database
+    save a workflow_job to the database. Can also be used to update a workflow_job
 
     Arguments:
         job_id: id of the workflow job
@@ -221,20 +231,28 @@ async def save_workflow_job(job_id: str, workflow_id: str, workspace_id: str, jo
         job_path: the path of the workflow job
         job_state: current state of the job
     """
-    workflow_job = WorkflowJobDB(
-        _id=job_id,
-        workflow_id=workflow_id,
-        workspace_id=workspace_id,
-        job_path=job_path,
-        job_state=job_state
-    )
-    await workflow_job.save()
-    return workflow_job
+    workflow_job_db = await get_workflow_job(job_id)
+    if not workflow_job_db:
+        workflow_job_db = WorkflowJobDB(
+            workflow_job_id=job_id,
+            workflow_id=workflow_id,
+            workspace_id=workspace_id,
+            job_path=job_path,
+            job_state=job_state
+        )
+    else:
+        workflow_job_db.workflow_job_id = job_id
+        workflow_job_db.workflow_id = workflow_id
+        workflow_job_db.workspace_id = workspace_id
+        workflow_job_db.job_path = job_path
+        workflow_job_db.job_state = job_state
+    await workflow_job_db.save()
+    return workflow_job_db
 
 
 @call_sync
 async def sync_save_workflow_job(job_id: str, workflow_id: str, workspace_id: str, job_path: str, job_state: str
-) -> Union[WorkflowJobDB, None]:
+                                 ) -> Union[WorkflowJobDB, None]:
     return await save_workflow_job(job_id, workflow_id, workspace_id, job_path, job_state)
 
 
@@ -242,7 +260,7 @@ async def set_workflow_job_state(job_id, job_state: str) -> bool:
     """
     set state of job to 'state'
     """
-    job = await WorkflowJobDB.get(job_id)
+    job = await get_workflow_job(job_id)
     if job:
         job.job_state = job_state
         await job.save()
@@ -260,7 +278,7 @@ async def get_workflow_job_state(job_id) -> Union[str, None]:
     """
     get state of job
     """
-    job = await WorkflowJobDB.get(job_id)
+    job = await get_workflow_job(job_id)
     if job:
         return job.job_state
     logger.warning(f"Trying to get a state of a non-existing workflow job: {job_id}")

--- a/ocrd_webapi/models/database.py
+++ b/ocrd_webapi/models/database.py
@@ -19,7 +19,7 @@ class WorkspaceDB(Document):
         bag_info_adds               bag-info.txt can also (optionally) contain additional
                                     key-value-pairs which are saved here
     """
-    id: str
+    workspace_id: str
     workspace_path: str
     workspace_mets_path: str
     ocrd_identifier: str

--- a/ocrd_webapi/models/database.py
+++ b/ocrd_webapi/models/database.py
@@ -37,7 +37,7 @@ class WorkflowDB(Document):
     """
     Model to store a workflow in the mongo-database.
     """
-    id: str
+    workflow_id: str
     workflow_path: str
     workflow_script_path: str
     deleted: bool = False
@@ -51,13 +51,13 @@ class WorkflowJobDB(Document):
     Model to store a Workflow-Job in the mongo-database.
 
     Attributes:
-        id            the job's id
-        workspace_id  id of the workspace on which this job is running
-        workflow_id   id of the workflow the job is executing
-        job_path      the path of the workflow job
-        job_state     current state of the workflow job
+        workflow_job_id   the job's id
+        workspace_id      id of the workspace on which this job is running
+        workflow_id       id of the workflow the job is executing
+        job_path          the path of the workflow job
+        job_state         current state of the workflow job
     """
-    id: str
+    workflow_job_id: str
     workspace_id: str
     workflow_id: str
     job_path: str

--- a/ocrd_webapi/routers/workflow.py
+++ b/ocrd_webapi/routers/workflow.py
@@ -96,8 +96,8 @@ async def get_workflow_job(workflow_id: str, job_id: str, accept: str = Header(d
         raise ResponseException(404, {})
 
     try:
-        wf_job_url = workflow_manager.get_resource_job(wf_job_db.workflow_id, wf_job_db.id, local=False)
-        wf_job_local = workflow_manager.get_resource_job(wf_job_db.workflow_id, wf_job_db.id, local=True)
+        wf_job_url = workflow_manager.get_resource_job(wf_job_db.workflow_id, wf_job_db.workflow_job_id, local=False)
+        wf_job_local = workflow_manager.get_resource_job(wf_job_db.workflow_id, wf_job_db.workflow_job_id, local=True)
         workflow_url = workflow_manager.get_resource(wf_job_db.workflow_id, local=False)
         workspace_url = WorkspaceManager.static_get_resource(wf_job_db.workspace_id, local=False)
         job_state = wf_job_db.job_state

--- a/tests/test_workflow_api.py
+++ b/tests/test_workflow_api.py
@@ -64,7 +64,7 @@ def test_post_workflow_script(client, auth, workflow_mongo_coll, asset_workflow1
 
     # Database checks
     workflow_from_db = workflow_mongo_coll.find_one()
-    assert_db_entry_created(workflow_from_db, workflow_id)
+    assert_db_entry_created(workflow_from_db, workflow_id, db_key="workflow_id")
 
 
 def test_put_workflow_script(client, auth, asset_workflow1, asset_workflow2, asset_workflow3):

--- a/tests/test_workspace_api.py
+++ b/tests/test_workspace_api.py
@@ -60,7 +60,7 @@ def test_post_workspace(client, auth, workspace_mongo_coll, asset_workspace1):
 
     # Database checks
     resource_from_db = workspace_mongo_coll.find_one()
-    assert_db_entry_created(resource_from_db, workspace_id)
+    assert_db_entry_created(resource_from_db, workspace_id, db_key="workspace_id")
 
 
 def test_post_workspace_different_mets(client, auth, workspace_mongo_coll, asset_workspace3):
@@ -72,7 +72,7 @@ def test_post_workspace_different_mets(client, auth, workspace_mongo_coll, asset
 
     # Database checks
     resource_from_db = workspace_mongo_coll.find_one()
-    assert_db_entry_created(resource_from_db, workspace_id)
+    assert_db_entry_created(resource_from_db, workspace_id, db_key="workspace_id")
 
 
 def test_put_workspace(client, auth, workspace_mongo_coll, asset_workspace1, asset_workspace2):
@@ -84,7 +84,7 @@ def test_put_workspace(client, auth, workspace_mongo_coll, asset_workspace1, ass
 
     # Database checks
     workspace_from_db = workspace_mongo_coll.find_one()
-    assert_db_entry_created(workspace_from_db, test_id)
+    assert_db_entry_created(workspace_from_db, test_id, db_key="workspace_id")
     ocrd_identifier1 = workspace_from_db["ocrd_identifier"]
 
     request2 = f"/workspace/{test_id}"

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -35,7 +35,7 @@ def parse_job_state(response):
         return None
 
 
-def assert_db_entry_created(resource_from_db, resource_id, db_key="_id"):
+def assert_db_entry_created(resource_from_db, resource_id, db_key):
     assert resource_from_db, \
         "Resource entry was not created in mongodb"
     db_id = resource_from_db[db_key]

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -40,7 +40,7 @@ def assert_db_entry_created(resource_from_db, resource_id, db_key="_id"):
         "Resource entry was not created in mongodb"
     db_id = resource_from_db[db_key]
     assert db_id == resource_id, \
-        "Wrong resource id. Expected: {resource_id}, found {db_id}"
+        f"Wrong resource id. Expected: {resource_id}, found {db_id}"
 
 
 def assert_db_entry_deleted(resource_from_db, db_key="deleted"):

--- a/things/nextflow-simple.nf
+++ b/things/nextflow-simple.nf
@@ -3,7 +3,6 @@ nextflow.enable.dsl = 2
 
 
 // pipeline parameters
-params.venv = "\$HOME/venv37-ocrd/bin/activate"
 params.workspace = "$projectDir/ocrd-workspace/"
 params.mets = "$projectDir/ocrd-workspace/mets.xml"
 params.input_group = "OCR-D-IMG"
@@ -21,9 +20,7 @@ process ocrd_dummy {
 
 	script:
 	"""
-	source "${params.venv}"
 	ocrd-dummy -I ${input_dir} -O ${output_dir}
-	deactivate
 	"""
 }
 


### PR DESCRIPTION
this comment is for the first 2 commits

Reason for he changes:
The Webapi is used together with the processing-server. The processing server starts the workers on localhost as the user provided in the configuration file. This is usually not root but the "normal" user (typically user-id 1000). I think it would not be a good idea to use root for that, as the processing-workers are not run in docker or another way of isolation.
Because of that files created by the webapi must be writable by the processing-workers and thus by the "normal" user (The webapi "creates" the files when users upload their workspaces and the webapi "spills" them).
To do that at first I just run the webapi with docker-compose and use `user: 1000:1000` inside so that the workspaces created had the needed owner. That worked fine until I tried to run workflows with the webapi as well. When the user is changed this way nextflow does not run due to several reasons. The changes I made to the Dockerfile bypass these problems.

Maybe it is a good idea to give the opportunity to get some feedback so I created this pull request. I am not sure if there are better ways to achieve the same. Usually inside containers everything is just run as root, I am not sure why, maybe I am missing something.